### PR TITLE
Annotation expanded bug fix.

### DIFF
--- a/views/modals/GeniusScreen.js
+++ b/views/modals/GeniusScreen.js
@@ -53,7 +53,9 @@ function GeniusScreen({ route }) {
         contentInset={{ top: baseUnit * 2, bottom: baseUnit * 8 }}
         estimatedItemSize={route.params.data.annotations.length}
         keyExtractor={(item, index) => index}
-        renderItem={({ item }) => <Annotation data={item} />}
+        renderItem={({ item }) => (
+          <Annotation key={item.annotations[0].id} data={item} />
+        )}
         refreshing={false}
         data={route.params.data.annotations.filter(
           (d) => inputText === "" || d.range.content.includes(inputText)


### PR DESCRIPTION
**Problem**
After performing a search on annotations and tapping to expand the item, if you press cancel to clear out the input text, the first annotation will be shown as expanded.

**Solution**
Added key prop to annotations.